### PR TITLE
Fix errors in 01-promise-basics

### DIFF
--- a/src/01-promise-basics/01-promise-basics-reject.js
+++ b/src/01-promise-basics/01-promise-basics-reject.js
@@ -14,7 +14,7 @@ let promise = new Promise(function (resolve, reject) {
 // but this time we are using the .catch
 const grandParentsCooking = () => {
   promise.catch(function (error) {
-    error(`OMG!!! ${error.message}`);
+    console.log(`OMG!!! ${error.message}`);
   });
 };
 

--- a/src/01-promise-basics/01-promise-basics-resolve.js
+++ b/src/01-promise-basics/01-promise-basics-resolve.js
@@ -13,7 +13,7 @@ const grandParentsCooking = () => {
   // The handler function to handle the resolved promise
   promise.then(function (result) {
     // Fetched the water. Now grandparents can start the cooking
-    log(`cooking rice with the ${result}`);
+    console.log(`cooking rice with the ${result}`);
   });
 };
 


### PR DESCRIPTION

# Description
Both changes are in the `grandParentsCooking` function:
* In **01-promise-basics-resolve.js** use `console.log` instead of `error`
* In **01-promise-basics-reject.js** use `console.log` instead of `log` 

Fixes # (issue) N/A

## Type of change

Please delete options that are not relevant.
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
Running both files with node don't result in errors, eg:
`node 01-promise-basics-resolve.js`
`node 01-promise-basics-reject.js`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
